### PR TITLE
disable checksum verification in download_and_extract

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
@@ -843,6 +843,9 @@ public class StarlarkRepositoryContext
       throws RepositoryFunctionException, InterruptedException, EvalException {
     Map<URI, Map<String, String>> authHeaders = getAuthHeaders(getAuthContents(auth, "auth"));
 
+    sha256 = "";
+    integrity = "";
+
     List<URL> urls =
         getUrls(
             url,


### PR DESCRIPTION
custom bazel build off of 4.2.1 that disables checksum verification in `download_and_extract`

artifact gcs objects: `gs://mixpanel-tools/build/bazel/bazel-4.2.1-disable-checksums-goot-linux-x86_64`